### PR TITLE
Fix link typo in about.html file

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,7 +85,7 @@
                                 <strong>Lead Developer &amp; Designer</strong></h6>
                             <div class="social-row display-7">
                                 <div class="socials">
-                                    <a href="https:/github.com/h4h13" target="_blank">
+                                    <a href="https://github.com/h4h13" target="_blank">
                                         <span class="icon-font icon-github"></span>
                                     </a>
                                 </div>


### PR DESCRIPTION
There was a typo (a missing slash '/') in the github link in the about file.
